### PR TITLE
Updating / fixing encoding functions

### DIFF
--- a/b2c.py
+++ b/b2c.py
@@ -177,12 +177,12 @@ class B2C:
 
         # clemintine stores some characters unencoded... it's not consistent with
         # the library.
-        path = (path.replace('%', '%%')
-                .replace('%%2C', ',').replace('%%28', '(')
-                .replace('%%29', ')').replace('%%27', "'")
-                .replace('%%26', '&').replace('%%2B', '+')
-                .replace('%%21', '!').replace('%%3B', ';')
-                .replace('%%3D', '=').replace('%%7E', '~')
+        path = (path.replace('%2C', ',').replace('%28', '(')
+                    .replace('%29', ')').replace('%27', "'")
+                    .replace('%26', '&').replace('%2B', '+')
+                    .replace('%21', '!').replace('%3B', ';')
+                    .replace('%3D', '=').replace('%7E', '~')
+                    .replace('%40', '@')
                 )
 
         return path

--- a/b2c.py
+++ b/b2c.py
@@ -171,7 +171,7 @@ class B2C:
     def _get_clementine_filename(self, path):
         """ Converts any path to a clemintine path """
         if not self._check_urlencode(path):
-            path = urllib.urlencode(path)
+            path = urllib.quote(path)
         if not path.startswith('file://'):
             path = 'file://' + path
 
@@ -190,7 +190,7 @@ class B2C:
     def _get_banshee_filename(self, path):
         """ Converts any path to a banshee path """
         if not self._check_urlencode(path):
-            path = urllib.urlencode(path)
+            path = urllib.quote(path)
         if not path.startswith('file://'):
             path = 'file://' + path
 

--- a/b2c.py
+++ b/b2c.py
@@ -71,7 +71,7 @@ class B2C:
                 path = self._uri_to_path(item['uri'])
                 if os.path.isfile(path) and self._is_audio_file(path):
                     nb_items += 1
-                    row_id = self._get_clementine_library_id(item['uri'])
+                    row_id = self._get_clementine_library_id(path)
                     if row_id is None:
                         logging.warn('%s is missing', path)
                     else:
@@ -275,7 +275,7 @@ class B2C:
         for pl_item in pl_cursor:
             path = self._uri_to_path(pl_item['uri'])
             if os.path.isfile(path) and self._is_audio_file(path):
-                library_id = self._get_clementine_library_id(pl_item['uri'])
+                library_id = self._get_clementine_library_id(path)
                 nb_added += 1
                 cursor.execute(query, {
                         'playlist_id': playlist_id,


### PR DESCRIPTION
Firstly, thanks for sharing this !
My library contains 7600 songs and a hundred playlists, so it encountered a few corner-cases when url-encoding file names.

So I've modified the script, which now correctly imports from Banshee 2.6.2 to Clementine 1.2.3.